### PR TITLE
Removed @Everyone render on the right side

### DIFF
--- a/src/main/java/io/github/noeppi_noeppi/mods/minemention/EventListener.java
+++ b/src/main/java/io/github/noeppi_noeppi/mods/minemention/EventListener.java
@@ -153,25 +153,4 @@ public class EventListener {
             }
         });
     }
-    
-    @SubscribeEvent
-    @OnlyIn(Dist.CLIENT)
-    public void renderChat(RenderGuiOverlayEvent.Post event) {
-        Minecraft mc = Minecraft.getInstance();
-        if (VanillaGuiOverlay.CHAT_PANEL.id().equals(event.getOverlay().id()) && mc.screen instanceof ChatScreen) {
-            PoseStack poseStack = event.getPoseStack();
-            poseStack.pushPose();
-            Font font = mc.font;
-            int width = font.width(ClientMentions.getCurrentDefault());
-            poseStack.translate(event.getWindow().getGuiScaledWidth() - (width + 6), event.getWindow().getGuiScaledHeight() - (2 * (font.lineHeight + 6)), 0);
-            RenderSystem.enableBlend();
-            RenderSystem.defaultBlendFunc();
-            RenderSystem.setShaderTexture(0, RenderHelper.TEXTURE_WHITE);
-            RenderSystem.setShaderColor(0, 0, 0, (float) (double) mc.options.textBackgroundOpacity().get());
-            GuiComponent.blit(poseStack, 0, 0, 0, 0, width + 4, font.lineHeight + 4, 256, 256);
-            RenderSystem.disableBlend();
-            font.drawShadow(poseStack, ClientMentions.getCurrentDefault(), 2, 2, 0xFFFFFF);
-            poseStack.popPose();
-        }
-    }
 }


### PR DESCRIPTION
Hi, I found this mod and liked it.
But there is something I find annoying.
It's the render on the right side of the chat. (https://i.imgur.com/KNr1Zmi.png)

I couldn't relly figure out what the purpose of it is. So I removed it because it overlaped with other mods like (Quark and No Chat Reports) Picture: https://i.imgur.com/IZshCev.png


If this render is needed for some kind of feature i didn't see. Then I would change the position to the left side. Picture: https://i.imgur.com/14enE3l.png

```
@SubscribeEvent
    @OnlyIn(Dist.CLIENT)
    public void renderChat(RenderGuiOverlayEvent.Post event) {
        Minecraft mc = Minecraft.getInstance();
        if (VanillaGuiOverlay.CHAT_PANEL.id().equals(event.getOverlay().id()) && mc.screen instanceof ChatScreen) {
            PoseStack poseStack = event.getPoseStack();
            poseStack.pushPose();
            Font font = mc.font;
            int width = font.width(ClientMentions.getCurrentDefault());
            poseStack.translate(event.getWindow().getGuiScaledWidth() - (event.getWindow().getGuiScaledWidth() - 5) , event.getWindow().getGuiScaledHeight() - (2 * (font.lineHeight + 6)), 0);
            RenderSystem.enableBlend();
            RenderSystem.defaultBlendFunc();
            RenderSystem.setShaderTexture(0, RenderHelper.TEXTURE_WHITE);
            RenderSystem.setShaderColor(0, 0, 0, (float) (double) mc.options.textBackgroundOpacity().get());
            GuiComponent.blit(poseStack, 0, 0, 0, 0, width + 4, font.lineHeight + 4, 256, 256);
            RenderSystem.disableBlend();
            font.drawShadow(poseStack, ClientMentions.getCurrentDefault(), 2, 2, 0xFFFFFF);
            poseStack.popPose();
        }
    }
```

This change needs to be done for the renderChat method if you want it on the left. But like I said, if there is no purpose, just remove it.